### PR TITLE
Update the div id referenced in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PixelPainter is a plugin that you will create. It has a color swatch of infinite
 ## Getting Started and Specs
 
 ### PixelPainter(_width_, _height_)
-When instatiated it appends a new PixelPainter object to a HTML div element with an id of **pp-canvas**.
+When instatiated it appends a new PixelPainter object to a HTML div element with an id of **pixelPainter**.
 
 **note**: you can use either the _Module_ or _Classical_ OOP Patterns for this.
 


### PR DESCRIPTION
Updated the readme to reference the correct div id of "pixelPainter" rather than the original "pp-canvas" to match the index.html file.